### PR TITLE
fix: hover样式丢失

### DIFF
--- a/desn-geo-view/src/com/normal/Normal.tsx
+++ b/desn-geo-view/src/com/normal/Normal.tsx
@@ -100,10 +100,13 @@ export default function Normal({mouseDown}) {
 
         setTimeout(v => {
           const stag = document.createElement("style");
-          document.head.appendChild(stag);
+          // document.head.appendChild(stag);
+          document.head.insertBefore(stag, document.head.querySelectorAll("style")[0])
 
           const styleSheets = document.styleSheets
-          const styleSheet = styleSheets[styleSheets.length - 1]
+          const styleSheet = styleSheets[0]
+          // const styleSheet = styleSheets[styleSheets.length - 1]
+          // const styleSheet = styleSheets[styleSheets.length - 2]
 
           styleSheet.addRule(`${model.id}-hover`, '');
 


### PR DESCRIPTION
点击调试后回到设计页面，hover样式丢失，未定位到丢失原因

将hover样式从头部进行添加样式不会丢失，暂时改为头部添加